### PR TITLE
`response` receives null explicitly from several catch clauses => Fix…

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
@@ -108,7 +109,7 @@ public final class WebSocketRecorder extends WebSocketListener {
     }
   }
 
-  @Override public void onFailure(WebSocket webSocket, Throwable t, Response response)  {
+  @Override public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response)  {
     Platform.get().log(Platform.INFO, "[WS " + name + "] onFailure", t);
 
     WebSocketListener delegate = this.delegate;

--- a/okhttp/src/main/java/okhttp3/WebSocketListener.java
+++ b/okhttp/src/main/java/okhttp3/WebSocketListener.java
@@ -15,6 +15,7 @@
  */
 package okhttp3;
 
+import javax.annotation.Nullable;
 import okio.ByteString;
 
 public abstract class WebSocketListener {
@@ -49,6 +50,6 @@ public abstract class WebSocketListener {
    * network. Both outgoing and incoming messages may have been lost. No further calls to this
    * listener will be made.
    */
-  public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+  public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
@@ -528,7 +529,7 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     }
   }
 
-  public void failWebSocket(Exception e, Response response) {
+  public void failWebSocket(Exception e, @Nullable Response response) {
     Streams streamsToClose;
     synchronized (this) {
       if (failed) return; // Already failed.


### PR DESCRIPTION
… nullability (override default parameter nullability set at package-info). (#3449)