### PR TITLE
Add workaround for https://issuetracker.google.com/issues/63649622 (#…

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -15,6 +15,7 @@
  */
 package okhttp3.internal.platform;
 
+import android.os.Build;
 import android.util.Log;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -76,6 +77,16 @@ class AndroidPlatform extends Platform {
       IOException ioException = new IOException("Exception in connect");
       ioException.initCause(e);
       throw ioException;
+    } catch (ClassCastException e) {
+      // On android 8.0, socket.connect throws a ClassCastException due to a bug
+      // see https://issuetracker.google.com/issues/63649622
+      if (Build.VERSION.SDK_INT == 26) {
+        IOException ioException = new IOException("Exception in connect");
+        ioException.initCause(e);
+        throw ioException;
+      } else {
+        throw e;
+      }
     }
   }
 


### PR DESCRIPTION
…3624)

* Add workaround for https://issuetracker.google.com/issues/63649622

This fixes #3438

* Rethrowing the Android O bug CCE as IOException