### PR TITLE
Update upstream

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -1033,6 +1033,43 @@ public final class CacheTest {
     assertEquals("ABCABCABC", get(server.url("/")).body().string());
   }
 
+  @Test public void previouslyNotGzippedContentIsNotModifiedAndSpecifiesGzipEncoding() throws Exception {
+    server.enqueue(new MockResponse()
+            .setBody("ABCABCABC")
+            .addHeader("Content-Type: text/plain")
+            .addHeader("Last-Modified: " + formatDate(-2, TimeUnit.HOURS))
+            .addHeader("Expires: " + formatDate(-1, TimeUnit.HOURS)));
+    server.enqueue(new MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED)
+            .addHeader("Content-Type: text/plain")
+            .addHeader("Content-Encoding: gzip"));
+    server.enqueue(new MockResponse()
+            .setBody("DEFDEFDEF"));
+
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("DEFDEFDEF", get(server.url("/")).body().string());
+  }
+
+  @Test public void changedGzippedContentIsNotModifiedAndSpecifiesNewEncoding() throws Exception {
+    server.enqueue(new MockResponse()
+            .setBody(gzip("ABCABCABC"))
+            .addHeader("Content-Type: text/plain")
+            .addHeader("Last-Modified: " + formatDate(-2, TimeUnit.HOURS))
+            .addHeader("Expires: " + formatDate(-1, TimeUnit.HOURS))
+            .addHeader("Content-Encoding: gzip"));
+    server.enqueue(new MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED)
+            .addHeader("Content-Type: text/plain")
+            .addHeader("Content-Encoding: identity"));
+    server.enqueue(new MockResponse()
+            .setBody("DEFDEFDEF"));
+
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("DEFDEFDEF", get(server.url("/")).body().string());
+  }
+
   @Test public void notModifiedSpecifiesEncoding() throws Exception {
     server.enqueue(new MockResponse()
         .setBody(gzip("ABCABCABC"))

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -224,17 +224,15 @@ public final class CacheInterceptor implements Interceptor {
       if ("Warning".equalsIgnoreCase(fieldName) && value.startsWith("1")) {
         continue; // Drop 100-level freshness warnings.
       }
-      if (!isEndToEnd(fieldName) || networkHeaders.get(fieldName) == null) {
+      if (isContentSpecificHeader(fieldName) || !isEndToEnd(fieldName)
+              || networkHeaders.get(fieldName) == null) {
         Internal.instance.addLenient(result, fieldName, value);
       }
     }
 
     for (int i = 0, size = networkHeaders.size(); i < size; i++) {
       String fieldName = networkHeaders.name(i);
-      if ("Content-Length".equalsIgnoreCase(fieldName)) {
-        continue; // Ignore content-length headers of validating responses.
-      }
-      if (isEndToEnd(fieldName)) {
+      if (!isContentSpecificHeader(fieldName) && isEndToEnd(fieldName)) {
         Internal.instance.addLenient(result, fieldName, networkHeaders.value(i));
       }
     }
@@ -255,5 +253,15 @@ public final class CacheInterceptor implements Interceptor {
         && !"Trailers".equalsIgnoreCase(fieldName)
         && !"Transfer-Encoding".equalsIgnoreCase(fieldName)
         && !"Upgrade".equalsIgnoreCase(fieldName);
+  }
+
+  /**
+   * Returns true if {@code fieldName} is content specific and therefore should always be used
+   * from cached headers.
+   */
+  static boolean isContentSpecificHeader(String fieldName) {
+    return "Content-Length".equalsIgnoreCase(fieldName)
+        || "Content-Encoding".equalsIgnoreCase(fieldName)
+        || "Content-Type".equalsIgnoreCase(fieldName);
   }
 }


### PR DESCRIPTION
* Added failing test for changing of content encoding from (gzip to identity)
* Remove Content-Encoding IF it was not present otherwise revert it to the previously stored Content-Encoding