### PR TITLE
Update upstream

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
@@ -72,7 +72,7 @@ public final class HostnameVerifierTest {
         + "HwlNrAu8jlZ2UqSgskSWlhYdMTAP9CPHiUv9N7FcT58Itv/I4fKREINQYjDpvQcx\n"
         + "SaTYb9dr5sB4WLNglk7zxDtM80H518VvihTcP7FHL+Gn6g4j5fkI98+S\n"
         + "-----END CERTIFICATE-----\n");
-    assertTrue(verifier.verify("foo.com", session));
+    assertFalse(verifier.verify("foo.com", session));
     assertFalse(verifier.verify("a.foo.com", session));
     assertFalse(verifier.verify("bar.com", session));
   }
@@ -105,7 +105,7 @@ public final class HostnameVerifierTest {
         + "9BsO7qe46hidgn39hKh1WjKK2VcL/3YRsC4wUi0PBtFW6ScMCuMhgIRXSPU55Rae\n"
         + "UIlOdPjjr1SUNWGId1rD7W16Scpwnknn310FNxFMHVI0GTGFkNdkilNCFJcIoRA=\n"
         + "-----END CERTIFICATE-----\n");
-    assertTrue(verifier.verify("\u82b1\u5b50.co.jp", session));
+    assertFalse(verifier.verify("\u82b1\u5b50.co.jp", session));
     assertFalse(verifier.verify("a.\u82b1\u5b50.co.jp", session));
   }
 
@@ -258,7 +258,7 @@ public final class HostnameVerifierTest {
     assertFalse(verifier.verify("a.foo.com", session));
     assertFalse(verifier.verify("bar.com", session));
     assertFalse(verifier.verify("a.bar.com", session));
-    assertTrue(verifier.verify("\u82b1\u5b50.co.jp", session));
+    assertFalse(verifier.verify("\u82b1\u5b50.co.jp", session));
     assertFalse(verifier.verify("a.\u82b1\u5b50.co.jp", session));
   }
 
@@ -291,8 +291,8 @@ public final class HostnameVerifierTest {
         + "l3Q/RK95bnA6cuRClGusLad0e6bjkBzx/VQ3VarDEpAkTLUGVAa0CLXtnyc=\n"
         + "-----END CERTIFICATE-----\n");
     assertFalse(verifier.verify("foo.com", session));
-    assertTrue(verifier.verify("www.foo.com", session));
-    assertTrue(verifier.verify("\u82b1\u5b50.foo.com", session));
+    assertFalse(verifier.verify("www.foo.com", session));
+    assertFalse(verifier.verify("\u82b1\u5b50.foo.com", session));
     assertFalse(verifier.verify("a.b.foo.com", session));
   }
 
@@ -325,8 +325,8 @@ public final class HostnameVerifierTest {
         + "UGPLEUDzRHMPHLnSqT1n5UU5UDRytbjJPXzF+l/+WZIsanefWLsxnkgAuZe/oMMF\n"
         + "EJMryEzOjg4Tfuc5qM0EXoPcQ/JlheaxZ40p2IyHqbsWV4MRYuFH4bkM\n"
         + "-----END CERTIFICATE-----\n");
-    assertTrue(verifier.verify("foo.co.jp", session));
-    assertTrue(verifier.verify("\u82b1\u5b50.co.jp", session));
+    assertFalse(verifier.verify("foo.co.jp", session));
+    assertFalse(verifier.verify("\u82b1\u5b50.co.jp", session));
   }
 
   /**
@@ -451,7 +451,7 @@ public final class HostnameVerifierTest {
         + "U6LFxmZr31lFyis2/T68PpjAppc0DpNQuA2m/Y7oTHBDi55Fw6HVHCw3lucuWZ5d\n"
         + "qUYo4ES548JdpQtcLrW2sA==\n"
         + "-----END CERTIFICATE-----");
-    assertTrue(verifier.verify("google.com", session));
+    assertFalse(verifier.verify("google.com", session));
   }
 
   @Test public void subjectAltName() throws Exception {

--- a/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
-import javax.security.auth.x500.X500Principal;
 
 import static okhttp3.internal.Util.verifyAsIpAddress;
 
@@ -73,24 +72,12 @@ public final class OkHostnameVerifier implements HostnameVerifier {
   /** Returns true if {@code certificate} matches {@code hostname}. */
   private boolean verifyHostname(String hostname, X509Certificate certificate) {
     hostname = hostname.toLowerCase(Locale.US);
-    boolean hasDns = false;
     List<String> altNames = getSubjectAltNames(certificate, ALT_DNS_NAME);
-    for (int i = 0, size = altNames.size(); i < size; i++) {
-      hasDns = true;
-      if (verifyHostname(hostname, altNames.get(i))) {
+    for (String altName : altNames) {
+      if (verifyHostname(hostname, altName)) {
         return true;
       }
     }
-
-    if (!hasDns) {
-      X500Principal principal = certificate.getSubjectX500Principal();
-      // RFC 2818 advises using the most specific name for matching.
-      String cn = new DistinguishedNameParser(principal).findMostSpecific("cn");
-      if (cn != null) {
-        return verifyHostname(hostname, cn);
-      }
-    }
-
     return false;
   }
 


### PR DESCRIPTION
The use of Common Name was deprecated in RFC 2818 (May 2000), section 3.1:

  Although the use of the Common Name is existing practice, it is
  deprecated and Certification Authorities are encouraged to use the
  dNSName instead.

In 2017, Chrome 58, Firefox 48, and Opera 45 web browsers removed this
fallback, with Chrome leaving it configurable for enterprise deployments
(see https://www.chromestatus.com/feature/4981025180483584).
Android is removing it in http://r.android.com/581382 .