### PR TITLE
Update upstream

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -108,7 +108,6 @@ public final class Http2ConnectionTest {
     Http2Stream stream = connection.newStream(headerEntries("a", "android"), false);
 
     assertEquals(3368, connection.peerSettings.getInitialWindowSize());
-    assertEquals(1684, connection.bytesLeftInWriteWindow); // initial wasn't affected.
     // New Stream is has the most recent initial window size.
     assertEquals(3368, stream.bytesLeftInWriteWindow);
   }
@@ -1234,7 +1233,6 @@ public final class Http2ConnectionTest {
     peer.sendFrame().ping(true, 1, 0);
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().synReply(false, 3, headerEntries("a", "android"));
-    peer.sendFrame().windowUpdate(3, 5);
     peer.acceptFrame(); // PING
     peer.sendFrame().ping(true, 3, 0);
     peer.acceptFrame(); // DATA

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -312,14 +312,6 @@ public final class Http2Connection implements Closeable {
     }
   }
 
-  /**
-   * {@code delta} will be negative if a settings frame initial window is smaller than the last.
-   */
-  void addBytesToWriteWindow(long delta) {
-    bytesLeftInWriteWindow += delta;
-    if (delta > 0) Http2Connection.this.notifyAll();
-  }
-
   void writeSynResetLater(final int streamId, final ErrorCode errorCode) {
     try {
       writerExecutor.execute(new NamedRunnable("OkHttp %s stream %d", hostname, streamId) {
@@ -709,7 +701,6 @@ public final class Http2Connection implements Closeable {
         if (peerInitialWindowSize != -1 && peerInitialWindowSize != priorWriteWindowSize) {
           delta = peerInitialWindowSize - priorWriteWindowSize;
           if (!receivedInitialPeerSettings) {
-            addBytesToWriteWindow(delta);
             receivedInitialPeerSettings = true;
           }
           if (!streams.isEmpty()) {


### PR DESCRIPTION
This might have been a difference between SPDY and HTTP/2. Reviewing the
HTTP/2 spec, only a WINDOWS_UPDATE frame can change the flow-control
window for a connection.