### PR TITLE
Update upstream

### DIFF
--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -55,6 +55,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -352,6 +352,7 @@ public final class StreamAllocation {
     closeQuietly(socket);
     if (releasedConnection != null) {
       eventListener.connectionReleased(call, releasedConnection);
+      eventListener.callEnd(call);
     }
   }
 


### PR DESCRIPTION
HTTP Logging interceptor breaks EventListener because of changed event ordering.  End the call on delayed release.