### PR TITLE
Text field style merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <java.version>1.7</java.version>
     <moshi.version>1.1.0</moshi.version>
     <jnr-unixsocket.version>0.19</jnr-unixsocket.version>
-    <okio.version>1.15.0</okio.version>
+    <okio.version>1.16.0</okio.version>
     <conscrypt.version>1.4.0</conscrypt.version>
 
     <!-- Test Dependencies -->


### PR DESCRIPTION
* Update Okio to 1.16.0.
* Use BufferedSource.peek() in Response.peekBody().