### PR TITLE
Cannot define global Stylus variables for CSS styling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 
 script:
- - ./gradlew check
+ - ./gradlew check --parallel
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ subprojects { project ->
     jvmArgs += "-Dlistener=okhttp3.testing.InstallUncaughtExceptionHandlerListener"
     jvmArgs += "-Dokhttp.platform=$platform"
 
+    maxParallelForks Runtime.runtime.availableProcessors() * 2
     testLogging {
       exceptionFormat = 'full'
     }


### PR DESCRIPTION
* Parallelize tests based on available processors

This brings down `:okhttp:test` (the biggest bottle neck) time on my local machine from ~2m11s to ~39s.

Build scans:
* Without parallelization: https://scans.gradle.com/s/nmjkdjflng4o4
* With parallelization: https://scans.gradle.com/s/3oebsmkfwetiy