### PR TITLE
npm audit corrupts non-tty's

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/concurrent/Task.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/Task.kt
@@ -67,20 +67,30 @@ abstract class Task(
     this.queue = queue
 
     this.runRunnable = Runnable {
+      val currentThread = Thread.currentThread()
+      val oldName = currentThread.name
+      currentThread.name = name
+
       var delayNanos = -1L
       try {
         delayNanos = runOnce()
       } finally {
         queue.runCompleted(this, delayNanos)
+        currentThread.name = oldName
       }
     }
 
     this.cancelRunnable = Runnable {
+      val currentThread = Thread.currentThread()
+      val oldName = currentThread.name
+      currentThread.name = name
+
       var skipExecution = false
       try {
         skipExecution = tryCancel()
       } finally {
         queue.tryCancelCompleted(this, skipExecution)
+        currentThread.name = oldName
       }
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
@@ -19,7 +19,6 @@ import okhttp3.internal.addIfAbsent
 import okhttp3.internal.notify
 import okhttp3.internal.objectWaitNanos
 import okhttp3.internal.threadFactory
-import java.util.concurrent.Executor
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -128,7 +127,7 @@ class TaskRunner(
   }
 
   class RealBackend : Backend {
-    private val coordinatorExecutor: Executor = ThreadPoolExecutor(
+    private val coordinatorExecutor = ThreadPoolExecutor(
         0, // corePoolSize.
         1, // maximumPoolSize.
         60L, TimeUnit.SECONDS, // keepAliveTime.
@@ -136,7 +135,7 @@ class TaskRunner(
         threadFactory("OkHttp Task Coordinator", false)
     )
 
-    private val taskExecutor: Executor = ThreadPoolExecutor(
+    private val taskExecutor = ThreadPoolExecutor(
         0, // corePoolSize.
         Int.MAX_VALUE, // maximumPoolSize.
         60L, TimeUnit.SECONDS, // keepAliveTime.
@@ -160,6 +159,11 @@ class TaskRunner(
 
     override fun coordinatorWait(taskRunner: TaskRunner, nanos: Long) {
       taskRunner.objectWaitNanos(nanos)
+    }
+
+    fun shutDown() {
+      coordinatorExecutor.shutdown()
+      taskExecutor.shutdown()
     }
   }
 }

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerRealBackendTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerRealBackendTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.concurrent
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.Test
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.TimeUnit
+
+/**
+ * Integration test to confirm that [TaskRunner] works with a real backend. Business logic is all
+ * exercised by [TaskRunnerTest].
+ *
+ * This test is doing real sleeping with tolerances of 250 ms. Hopefully that's enough for even the
+ * busiest of CI servers.
+ */
+class TaskRunnerRealBackendTest {
+  private val backend = TaskRunner.RealBackend()
+  private val taskRunner = TaskRunner(backend)
+  private val queue = taskRunner.newQueue("queue")
+  private val log = LinkedBlockingDeque<String>()
+
+  @Test fun test() {
+    val t1 = System.nanoTime() / 1e6
+
+    queue.schedule(object : Task("task", false) {
+      val delays = mutableListOf(TimeUnit.MILLISECONDS.toNanos(1000), -1L)
+      override fun runOnce(): Long {
+        log.put("runOnce delays.size=${delays.size}")
+        return delays.removeAt(0)
+      }
+    }, TimeUnit.MILLISECONDS.toNanos(750))
+
+    assertThat(log.take()).isEqualTo("runOnce delays.size=2")
+    val t2 = System.nanoTime() / 1e6 - t1
+    assertThat(t2).isCloseTo(750.0, Offset.offset(250.0))
+
+    assertThat(log.take()).isEqualTo("runOnce delays.size=1")
+    val t3 = System.nanoTime() / 1e6 - t1
+    assertThat(t3).isCloseTo(1750.0, Offset.offset(250.0))
+
+    backend.shutDown()
+  }
+}


### PR DESCRIPTION
* Set the thread name to the currently-executing task's name.

Also implement tests for thread interruption.
Also add a test that uses the real backend.

* Update okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt

Co-Authored-By: Yuri Schimke <yuri@schimke.ee>