### PR TITLE
Off-by-one in generated 

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/ErrorCode.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/ErrorCode.kt
@@ -26,6 +26,12 @@ enum class ErrorCode constructor(val httpCode: Int) {
 
   FLOW_CONTROL_ERROR(3),
 
+  SETTINGS_TIMEOUT(4),
+
+  STREAM_CLOSED(5),
+
+  FRAME_SIZE_ERROR(6),
+
   REFUSED_STREAM(7),
 
   CANCEL(8),


### PR DESCRIPTION
…_SIZE_ERROR) (#5550)

Missing codes added from https://tools.ietf.org/html/rfc7540#section-11.4